### PR TITLE
CSS actualizado

### DIFF
--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -16,6 +16,7 @@
   position: relative;
   overflow: hidden;
   background-image: url("");
+  background-size: 100%;
 }
 
 @media screen and (max-width: 966px) {


### PR DESCRIPTION
Se le dio un tamaño de 100% al fondo del `heroBanner` o imagen del principio de la página.
Así haciendo que no se vea medio raro o duplicada esa imagen.